### PR TITLE
Auto-create agent working directory if it does not exist

### DIFF
--- a/daemon/src/agents.ts
+++ b/daemon/src/agents.ts
@@ -139,10 +139,13 @@ export function buildSystemPrompt(agent: AgentConfig, agentDir: string, channel:
 }
 
 export function getAgentCwd(agent: AgentConfig): string {
-  if (!agent.cwd) return path.join(Config.workspaceDir, "agents", agent.id);
-  if (agent.cwd.startsWith("~")) return path.join(os.homedir(), agent.cwd.slice(1));
-  if (path.isAbsolute(agent.cwd)) return agent.cwd;
-  return path.join(Config.workspaceDir, agent.cwd);
+  let cwd: string;
+  if (!agent.cwd) cwd = path.join(Config.workspaceDir, "agents", agent.id);
+  else if (agent.cwd.startsWith("~")) cwd = path.join(os.homedir(), agent.cwd.slice(1));
+  else if (path.isAbsolute(agent.cwd)) cwd = agent.cwd;
+  else cwd = path.join(Config.workspaceDir, agent.cwd);
+  fs.mkdirSync(cwd, { recursive: true });
+  return cwd;
 }
 
 export function loadSettings(): Settings {


### PR DESCRIPTION
## Summary

- `getAgentCwd()` now creates the directory with `mkdirSync({ recursive: true })` before returning it
- Covers both default workspace cwd and custom paths from `agent.json`
- No-op if the directory already exists

Fixes #3

## Test plan

- [ ] Create an agent with a custom `cwd` pointing to a non-existent directory
- [ ] Send a message — verify the directory is created and the agent works

🤖 Generated with [Claude Code](https://claude.com/claude-code)