### PR TITLE
Include local time and timezone in agent system prompt

### DIFF
--- a/daemon/src/agents.ts
+++ b/daemon/src/agents.ts
@@ -133,9 +133,16 @@ export function buildMemoryPrompt(agentDir: string): string {
   return `\n<Memories>\n${sections.join("\n\n")}\n</Memories>`;
 }
 
+function buildContextBlock(): string {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const now = new Date();
+  const local = now.toLocaleString("en-US", { timeZone: tz, dateStyle: "full", timeStyle: "short" });
+  return `\n<Context>\nCurrent time: ${local} (${tz})\n</Context>`;
+}
+
 export function buildSystemPrompt(agent: AgentConfig, agentDir: string, channel: ChannelType, security: SecurityLevel): string {
   const memories = buildMemoryPrompt(agentDir);
-  return `<Role>\n${agent.role}\n</Role>\n${SECURITY_INSTRUCTIONS[security]}\n${GENERAL_INSTRUCTIONS}\n${FORMATTING_INSTRUCTIONS[channel]}${memories}`;
+  return `<Role>\n${agent.role}\n</Role>\n${SECURITY_INSTRUCTIONS[security]}\n${GENERAL_INSTRUCTIONS}\n${FORMATTING_INSTRUCTIONS[channel]}${buildContextBlock()}${memories}`;
 }
 
 export function getAgentCwd(agent: AgentConfig): string {


### PR DESCRIPTION
## Summary

- Adds a `<Context>` block to the system prompt with the current local time and IANA timezone
- Agents now correctly know whether it's morning, afternoon, or evening for the user

Example: `Current time: Monday, February 3, 2026, 2:15 PM (Europe/Helsinki)`

Fixes #11

## Test plan

- [ ] Send a message and verify the agent greets appropriately for the time of day

🤖 Generated with [Claude Code](https://claude.com/claude-code)