### PR TITLE
Show error message in Telegram when Claude invocation fails

### DIFF
--- a/daemon/src/channels/telegram.ts
+++ b/daemon/src/channels/telegram.ts
@@ -83,6 +83,13 @@ export function startTelegram() {
     });
   });
 
+  bus.on("thread:error", (payload) => {
+    if (payload.channel !== "telegram") return;
+    bot.api.sendMessage(Number(config.chatId), `⚠ Error: ${payload.error}`).catch((err) => {
+      log.error("telegram", "failed to deliver thread:error:", err);
+    });
+  });
+
   bot.on("message:text", async (ctx) => {
     const chatId = ctx.chat.id;
     let text = ctx.message.text;

--- a/daemon/src/events.ts
+++ b/daemon/src/events.ts
@@ -8,6 +8,12 @@ interface DaemonEvents {
     channel: ChannelType;
     text: string;
   }];
+  "thread:error": [payload: {
+    agentId: string;
+    threadId: string;
+    channel: ChannelType;
+    error: string;
+  }];
 }
 
 class TypedEmitter extends EventEmitter {

--- a/daemon/src/runner.ts
+++ b/daemon/src/runner.ts
@@ -60,6 +60,18 @@ export async function runThread(
       );
     } catch (err) {
       log.error("runner", `thread ${threadId} for agent ${agentId} failed:`, err);
+      const errorMsg = (err as Error).message ?? "unknown error";
+      appendMessage(filePath, {
+        role: "assistant",
+        text: `(error: ${errorMsg})`,
+        timestamp: new Date().toISOString(),
+      });
+      bus.emit("thread:error", {
+        agentId,
+        threadId,
+        channel: manifest.channel,
+        error: errorMsg,
+      });
       throw err;
     }
 


### PR DESCRIPTION
## Summary

- Adds `thread:error` event to the event bus
- Runner emits the event on failure and appends the error to the thread history
- Telegram handler sends the error message to the user so failures are never silent

Fixes #13

## Test plan

- [ ] Simulate a failure (e.g. invalid API key) and verify the error appears in Telegram
- [ ] Verify the error is recorded in the thread .jsonl file

🤖 Generated with [Claude Code](https://claude.com/claude-code)