### PR TITLE
Show generic error message in Telegram instead of internal details

### DIFF
--- a/daemon/src/channels/telegram.ts
+++ b/daemon/src/channels/telegram.ts
@@ -85,7 +85,7 @@ export function startTelegram() {
 
   bus.on("thread:error", (payload) => {
     if (payload.channel !== "telegram") return;
-    bot.api.sendMessage(Number(config.chatId), `⚠ Error: ${payload.error}`).catch((err) => {
+    bot.api.sendMessage(Number(config.chatId), "Something went wrong. Check the logs for details.").catch((err) => {
       log.error("telegram", "failed to deliver thread:error:", err);
     });
   });


### PR DESCRIPTION
## Summary

- Changes the Telegram error message from exposing the internal error string to a generic "Something went wrong. Check the logs for details."
- The full error is still logged at ERROR level and recorded in the thread history for debugging

Follows up on #13

## Test plan

- [ ] Simulate a failure and verify Telegram shows the generic message
- [ ] Verify the detailed error is in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)