### PR TITLE
Add memory usage guidelines to agent system prompts

### DIFF
--- a/daemon/src/agents.ts
+++ b/daemon/src/agents.ts
@@ -61,6 +61,19 @@ For example: "Let me check your calendar for tomorrow." or "I'll look that up fo
 Keep it short and natural. Do not narrate every single tool call — just the key steps.
 </StatusNarration>`;
 
+const MEMORY_INSTRUCTIONS = `
+<Memory>
+You have three ways to persist information:
+
+Files — for anything the user might want to read, edit, or reference later: notes, plans, research, lists, reports, structured data. If in doubt, use a file. Use your working directory.
+
+Agent memory (save_memory with scope "agent") — for things you need to remember but the user doesn't need to see as files: their preferences relevant to your domain, past decisions, recurring patterns, corrections they gave you, and important context for future conversations.
+
+Global memory (save_memory with scope "global") — for cross-agent knowledge any agent should know: the user's name, general preferences, timezone, communication style, and important facts about them.
+
+Save a memory when the user tells you something worth remembering, makes a decision, corrects you, or states a preference. Don't store transient details, information already in files, or verbatim conversation logs. Update or delete memories when they become outdated.
+</Memory>`;
+
 const FORMATTING_INSTRUCTIONS: Record<string, string> = {
   telegram: `
 <Formatting>
@@ -169,7 +182,8 @@ export function buildSystemPrompt(agent: AgentConfig, agentDir: string, channel:
   const dirBlock = buildDirectoriesBlock(cwd, directories, security);
   const baseChannel = channel.startsWith("telegram") ? "telegram" : channel;
   const formatting = FORMATTING_INSTRUCTIONS[baseChannel] ?? "";
-  return `<Role>\n${agent.role}\n</Role>\n${SECURITY_INSTRUCTIONS[security]}${dirBlock}\n${GENERAL_INSTRUCTIONS}\n${formatting}${buildContextBlock()}${memories}`;
+  const memoryInstructions = security !== "sandbox" ? MEMORY_INSTRUCTIONS : "";
+  return `<Role>\n${agent.role}\n</Role>\n${SECURITY_INSTRUCTIONS[security]}${dirBlock}\n${GENERAL_INSTRUCTIONS}${memoryInstructions}\n${formatting}${buildContextBlock()}${memories}`;
 }
 
 function resolveDirectory(rawPath: string): string {


### PR DESCRIPTION
## Summary

Closes #5

- Adds a `<Memory>` instruction block to agent system prompts with clear guidelines on when to use each storage option:
  - **Files** — for anything the user might want to read, edit, or reference later
  - **Agent memory** — for domain-specific preferences, past decisions, corrections
  - **Global memory** — for cross-agent user info (name, timezone, general preferences)
- Only injected for non-sandbox agents (sandbox agents don't have memory tools)

## Test plan

- [ ] `npm run build` passes
- [ ] Standard agent system prompt includes `<Memory>` block
- [ ] Sandbox agent system prompt does not include it

🤖 Generated with [Claude Code](https://claude.com/claude-code)