### PR TITLE
Improve agent-switch prompt and use haiku

### DIFF
--- a/daemon/src/channels/telegram.ts
+++ b/daemon/src/channels/telegram.ts
@@ -329,9 +329,9 @@ export function startTelegram() {
       bot.api.sendChatAction(chatId, "typing").catch(() => {});
     }, 4000);
     bot.api.sendChatAction(chatId, "typing").catch(() => {});
-    runThread(agentDir, threadId, "greet the user", undefined, {
+    runThread(agentDir, threadId, "The user just switched to you. Greet them briefly, then in 1-2 sentences help them reorient — recap where you left off, any open questions or pending tasks. If there's no prior context, just say hi and what you can help with. Keep it short.", undefined, {
       triggers: createTriggerMcpServer(agentDir, "telegram"),
-    }).catch((err) => {
+    }, undefined, undefined, { model: "haiku", maxTurns: 1 }).catch((err) => {
       log.error("telegram", `greeting failed for ${agentId}:`, (err as Error).message);
     }).finally(() => {
       clearInterval(typingInterval);

--- a/daemon/src/claude.ts
+++ b/daemon/src/claude.ts
@@ -7,6 +7,8 @@ export interface ClaudeOptions {
   additionalDirectories?: string[];
   systemPrompt?: string;
   security?: SecurityLevel;
+  model?: "sonnet" | "opus" | "haiku";
+  maxTurns?: number;
   agents?: Record<string, { description: string; prompt: string; tools?: string[]; disallowedTools?: string[]; model?: "sonnet" | "opus" | "haiku"; maxTurns?: number }>;
   mcpServers?: Record<string, McpServerConfig>;
 }
@@ -119,6 +121,8 @@ async function execClaude(
       ...(options.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),
       ...(options.agents ? { agents: options.agents } : {}),
       ...(options.mcpServers ? { mcpServers: options.mcpServers } : {}),
+      ...(options.model ? { model: options.model } : {}),
+      ...(options.maxTurns ? { maxTurns: options.maxTurns } : {}),
       ...securityOptions(security),
       ...(sessionId ? { resume: sessionId } : {}),
       ...(abortController ? { abortController } : {}),

--- a/daemon/src/runner.ts
+++ b/daemon/src/runner.ts
@@ -16,6 +16,11 @@ import {
 } from "./threads.js";
 import { log } from "./logger.js";
 
+export interface RunThreadOverrides {
+  model?: "sonnet" | "opus" | "haiku";
+  maxTurns?: number;
+}
+
 export async function runThread(
   agentDir: string,
   threadId: string,
@@ -24,6 +29,7 @@ export async function runThread(
   extraMcpServers?: Record<string, McpServerConfig>,
   askAgentDepth?: number,
   abortController?: AbortController,
+  overrides?: RunThreadOverrides,
 ): Promise<{ text: string }> {
   return withThreadLock(threadId, async () => {
     const filePath = threadPath(agentDir, threadId);
@@ -54,6 +60,8 @@ export async function runThread(
           ...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
           systemPrompt: buildSystemPrompt(agent, agentDir, manifest.channel, security),
           security,
+          ...(overrides?.model ? { model: overrides.model } : {}),
+          ...(overrides?.maxTurns ? { maxTurns: overrides.maxTurns } : {}),
           ...(agent.subagents ? { agents: agent.subagents } : {}),
           mcpServers: {
             memory: createMemoryMcpServer(agentDir),


### PR DESCRIPTION
## Summary
- Replace generic `"greet the user"` prompt with a context-aware prompt that greets briefly then recaps where the conversation left off
- Use haiku model with `maxTurns: 1` for fast, cheap agent-switch responses
- Add `model` and `maxTurns` override support to `ClaudeOptions` and `runThread` for reuse

Closes #35

## Test plan
- [ ] Switch agents in Telegram — verify greeting is fast and contextual
- [ ] Switch to an agent with no prior conversation — verify it introduces itself briefly

🤖 Generated with [Claude Code](https://claude.com/claude-code)