### PR TITLE
Fix trigger validation rejecting missing lastRun field

### DIFF
--- a/daemon/src/schemas.ts
+++ b/daemon/src/schemas.ts
@@ -27,7 +27,7 @@ export const TriggerSchema = z.object({
   tz: z.string().optional(),
   prompt: z.string(),
   enabled: z.boolean(),
-  lastRun: z.string().nullable(),
+  lastRun: z.string().nullable().optional(),
 });
 
 export type Trigger = z.infer<typeof TriggerSchema>;


### PR DESCRIPTION
## Summary
- Make `lastRun` optional in `TriggerSchema` so triggers without the field pass validation
- Fixes the `weekly-usage` trigger (and any future triggers) being silently skipped by the scheduler

Closes #43

## Context

The workspace template ships a `weekly-usage` trigger without `lastRun`. The schema required it to be `string | null`, rejecting `undefined`. This caused a `WARN [trigger] skipping invalid trigger in nova` log every 60 seconds, and the trigger never fired.

The scheduler already handles missing `lastRun` by treating it as epoch 0, so the schema was stricter than necessary.

## Test plan
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Start daemon and confirm no "skipping invalid trigger" warnings in `~/.nova/logs/daemon.log`
- [ ] Confirm `weekly-usage` trigger fires at its scheduled time

🤖 Generated with [Claude Code](https://claude.com/claude-code)