### PR TITLE
Simplify agent directory handling

### DIFF
--- a/daemon/src/agent-management.ts
+++ b/daemon/src/agent-management.ts
@@ -32,7 +32,6 @@ interface AgentJson {
   name: string;
   description?: string;
   role: string;
-  cwd?: string;
   directories?: string[];
   allowedAgents?: string[];
   [key: string]: unknown;
@@ -97,8 +96,7 @@ export function createAgentManagementMcpServer(): McpSdkServerConfigWithInstance
           name: z.string().describe("Display name"),
           description: z.string().optional().describe("Short description of what this agent does — shown to other agents for delegation discovery"),
           role: z.string().describe("System prompt / role"),
-          cwd: z.string().optional().describe("Primary working directory (optional)"),
-          directories: z.array(z.string()).optional().describe("Additional directories the agent can access (optional)"),
+          directories: z.array(z.string()).optional().describe("Directories the agent can access (optional)"),
           allowedAgents: z.array(z.string()).optional().describe("Agent IDs this agent can call via ask_agent (use [\"*\"] for any)"),
         },
         async (args) => {
@@ -114,7 +112,6 @@ export function createAgentManagementMcpServer(): McpSdkServerConfigWithInstance
 
           const data: AgentJson = { name: args.name, role: args.role };
           if (args.description) data.description = args.description;
-          if (args.cwd) data.cwd = args.cwd;
           if (args.directories && args.directories.length > 0) data.directories = args.directories;
           if (args.allowedAgents && args.allowedAgents.length > 0) data.allowedAgents = args.allowedAgents;
           writeAgentJson(args.id, data);
@@ -130,8 +127,7 @@ export function createAgentManagementMcpServer(): McpSdkServerConfigWithInstance
           name: z.string().optional().describe("New display name"),
           description: z.string().optional().describe("New short description"),
           role: z.string().optional().describe("New system prompt / role"),
-          cwd: z.string().optional().describe("New primary working directory"),
-          directories: z.array(z.string()).optional().describe("New list of additional directories (replaces existing list)"),
+          directories: z.array(z.string()).optional().describe("New list of directories (replaces existing list)"),
           allowedAgents: z.array(z.string()).optional().describe("Agent IDs this agent can call via ask_agent (use [\"*\"] for any)"),
         },
         async (args) => {
@@ -144,7 +140,6 @@ export function createAgentManagementMcpServer(): McpSdkServerConfigWithInstance
           if (args.name !== undefined) config.name = args.name;
           if (args.description !== undefined) config.description = args.description;
           if (args.role !== undefined) config.role = args.role;
-          if (args.cwd !== undefined) config.cwd = args.cwd;
           if (args.directories !== undefined) config.directories = args.directories;
           if (args.allowedAgents !== undefined) config.allowedAgents = args.allowedAgents;
 

--- a/daemon/src/agents.ts
+++ b/daemon/src/agents.ts
@@ -19,7 +19,6 @@ export interface AgentConfig {
   name: string;
   description?: string;
   role: string;
-  cwd?: string;
   directories?: string[];
   allowedAgents?: string[];
   security?: SecurityLevel;
@@ -193,9 +192,7 @@ function resolveDirectory(rawPath: string): string {
 }
 
 export function getAgentCwd(agent: AgentConfig): string {
-  const cwd = agent.cwd
-    ? resolveDirectory(agent.cwd)
-    : path.join(Config.workspaceDir, "agents", agent.id);
+  const cwd = path.join(Config.workspaceDir, "agents", agent.id);
   fs.mkdirSync(cwd, { recursive: true });
   return cwd;
 }

--- a/daemon/src/claude.ts
+++ b/daemon/src/claude.ts
@@ -4,7 +4,7 @@ import { log } from "./logger.js";
 
 export interface ClaudeOptions {
   cwd?: string;
-  additionalDirectories?: string[];
+  directories?: string[];
   systemPrompt?: string;
   security?: SecurityLevel;
   model?: "sonnet" | "opus" | "haiku";
@@ -126,7 +126,7 @@ async function execClaude(
     prompt,
     options: {
       ...(options.cwd ? { cwd: options.cwd } : {}),
-      ...(options.additionalDirectories && options.additionalDirectories.length > 0 ? { additionalDirectories: options.additionalDirectories } : {}),
+      ...(options.directories && options.directories.length > 0 ? { additionalDirectories: options.directories } : {}),
       ...(options.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),
       ...(options.agents ? { agents: options.agents } : {}),
       ...(options.mcpServers ? { mcpServers: options.mcpServers } : {}),

--- a/daemon/src/runner.ts
+++ b/daemon/src/runner.ts
@@ -53,12 +53,12 @@ export async function runThread(
 
     let result;
     try {
-      const additionalDirectories = getAgentDirectories(agent);
+      const directories = getAgentDirectories(agent);
       result = await runClaude(
         message,
         {
           cwd: getAgentCwd(agent),
-          ...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
+          ...(directories.length > 0 ? { directories } : {}),
           systemPrompt: buildSystemPrompt(agent, agentDir, manifest.channel, security),
           security,
           ...(overrides?.model ? { model: overrides.model } : {}),


### PR DESCRIPTION
## Summary

- Remove `cwd` field from agent config - agents always use their agent directory (`~/.nova/agents/{id}/`) as cwd
- Rename internal `additionalDirectories` to `directories`
- User-specified paths go to `directories` for additional access beyond the agent directory

This simplifies the mental model: the agent directory is always the working directory, and any extra paths the agent needs access to are just "directories".

Closes #37

## Test plan

- [ ] Build daemon: `npm run build`
- [ ] Test an agent with no `directories` config
- [ ] Test an agent with `directories` config - verify they're accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)