### PR TITLE
feat: add Agent Memory section to Console UI

### DIFF
--- a/src/api/console-agents.ts
+++ b/src/api/console-agents.ts
@@ -153,6 +153,18 @@ export function createConsoleAgentsRouter(workspaceDir: string): Hono {
       }
     }
 
+    // Handle memory separately — it's stored as a file, not in agent.json
+    if ("memory" in body) {
+      const memoryPath = path.join(agentDir(id), "memory.md")
+      const memoryValue = body.memory
+      if (memoryValue && typeof memoryValue === "string" && memoryValue.trim()) {
+        fs.mkdirSync(path.dirname(memoryPath), { recursive: true })
+        fs.writeFileSync(memoryPath, memoryValue, "utf-8")
+      } else {
+        try { fs.unlinkSync(memoryPath) } catch { /* already gone */ }
+      }
+    }
+
     agentStore.update(id, partial as Partial<AgentJsonInput>)
 
     const updated = agentStore.get(id)

--- a/web/console/src/components/AgentMemory.tsx
+++ b/web/console/src/components/AgentMemory.tsx
@@ -1,0 +1,32 @@
+import { Label } from "@/components/ui/label";
+import { AutoResizeTextarea } from "@/components/AutoResizeTextarea";
+import { useAutoSave } from "@/hooks/use-auto-save";
+
+interface AgentMemoryProps {
+  agentId: string;
+  memory: string;
+  onMemoryChange: (value: string) => void;
+}
+
+export function AgentMemory({
+  agentId,
+  memory,
+  onMemoryChange,
+}: AgentMemoryProps) {
+  useAutoSave(agentId, "memory", memory);
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="agent-memory">Memory</Label>
+      <p className="text-xs text-muted-foreground">
+        Agent's personal knowledge index — persisted across conversations
+      </p>
+      <AutoResizeTextarea
+        id="agent-memory"
+        value={memory}
+        onChange={onMemoryChange}
+        minRows={8}
+      />
+    </div>
+  );
+}

--- a/web/console/src/pages/AgentDetailPage.tsx
+++ b/web/console/src/pages/AgentDetailPage.tsx
@@ -8,6 +8,7 @@ import { CollapsibleCard } from "@/components/ui/collapsible-card";
 import { AgentHeader } from "@/components/AgentHeader";
 import { AgentIdentity } from "@/components/AgentIdentity";
 import { AgentResponsibilities } from "@/components/AgentResponsibilities";
+import { AgentMemory } from "@/components/AgentMemory";
 import { AgentCapabilities } from "@/components/AgentCapabilities";
 import { AgentDirectories } from "@/components/AgentDirectories";
 import { AgentSkills } from "@/components/AgentSkills";
@@ -30,6 +31,7 @@ export function AgentDetailPage() {
   const [responsibilities, setResponsibilities] = useState<Responsibility[]>([]);
   const [capabilities, setCapabilities] = useState<Record<string, { tools?: string[] }>>({});
   const [directories, setDirectories] = useState<string[]>([]);
+  const [memory, setMemory] = useState("");
 
   useEffect(() => {
     if (!id) return;
@@ -44,6 +46,7 @@ export function AgentDetailPage() {
         setResponsibilities(data.responsibilities ?? []);
         setCapabilities(data.capabilities ?? {});
         setDirectories(data.directories ?? []);
+        setMemory(data.memory ?? "");
       })
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
@@ -152,6 +155,18 @@ export function AgentDetailPage() {
           agentId={id}
           responsibilities={responsibilities}
           onResponsibilitiesChange={setResponsibilities}
+        />
+      </CollapsibleCard>
+
+      {/* Agent Memory */}
+      <CollapsibleCard
+        title="Agent Memory"
+        description={memory.trim() ? memory.trim().slice(0, 80) + (memory.trim().length > 80 ? "…" : "") : "No memory content"}
+      >
+        <AgentMemory
+          agentId={id}
+          memory={memory}
+          onMemoryChange={setMemory}
         />
       </CollapsibleCard>
 

--- a/web/console/src/types.ts
+++ b/web/console/src/types.ts
@@ -25,6 +25,7 @@ export interface Agent {
   directories?: string[];
   skills: string[];
   triggers: Trigger[];
+  memory?: string | null;
 }
 
 export interface AgentsResponse {


### PR DESCRIPTION
## Summary
- Add `memory` field to the Agent type and display it as an editable "Agent Memory" section in the Console agent detail page (after Responsibilities)
- Handle `memory` in the PATCH endpoint by writing/deleting `memory.md` in the agent directory
- New `AgentMemory` component follows the existing `AgentIdentity` pattern with `useAutoSave` for debounced persistence

## Test plan
- [ ] Open Console → agent detail → verify "Agent Memory" section appears after Responsibilities
- [ ] Edit memory text → verify auto-saves after 1s debounce
- [ ] Reload page → verify content persists
- [ ] Clear memory → verify `memory.md` is deleted on disk
- [ ] `npm run build` in `web/console` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)